### PR TITLE
Improved composer install process. 

### DIFF
--- a/installation/prepare_server.sh
+++ b/installation/prepare_server.sh
@@ -94,12 +94,23 @@ function installNodeJs {
 
 ##
 # Globally install composer.
+# See https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md for more information.
 ##
 function installComposer {
+	echo "${GREEN}Installing composer...${RESET}"
+	EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
 	php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-	php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-	php composer-setup.php --install-dir=/usr/local/bin/ --filename=composer
-	php -r "unlink('composer-setup.php');"
+	ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+	if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+	then
+		>&2 echo 'ERROR: Invalid composer installer signature'
+		rm composer-setup.php
+		return;
+	fi
+
+	php composer-setup.php  --install-dir=/usr/local/bin/ --filename=composer
+	rm composer-setup.php
 }
 
 ##


### PR DESCRIPTION
The current version of composer install function is corrupt because of outdated installer signature.
```
Installer corrupt
Could not open input file: composer-setup.php
PHP Warning:  unlink(composer-setup.php): No such file or directory in Command line code on line 1
```
Proposed changes are based on 
https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md